### PR TITLE
Allow config of upstream authorization platform attributes

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -14,7 +14,10 @@ app = Flask(__name__, host_matching=True, static_host=cfg.get('DOMAINS', 'idp_do
 
 app.config['app_version'] = "2.4.0"
 app.config['ife_IDP_DOMAIN'] = cfg.get('DOMAINS', 'idp_domain')
-app.config['ife_AUTHENTIK_DOMAIN'] = cfg.get('DOMAINS', 'authentik_domain')
+app.config['ife_UPSTREAM_SSO_DOMAIN'] = cfg.get('DOMAINS', 'upstream_sso_domain')
+app.config['ife_UPSTREAM_COOKIE'] = cfg.get('DOMAINS', 'upstream_cookie')
+app.config['ife_UPSTREAM_SSO_PATH'] = cfg.get('DOMAINS', 'upstream_sso_path')
+
 app.config['ife_IDP_PROTOCOL'] = "https://"
 app.config['ife_GLOBAL_SSO_DOMAIN'] = cfg.get('DOMAINS', 'sso_domain')
 app.config['ife_MATTERMOST_URL'] = cfg.get('DOMAINS', 'mattermost_url')

--- a/flaskr/router.py
+++ b/flaskr/router.py
@@ -51,7 +51,7 @@ def inject_template_globals():
         'CF_ip_country': request.headers.get('CF-IPCountry', "-"),
         'portal_app_version': app.config['app_version'] ,
         'ife_MATTERMOST_URL': app.config['ife_MATTERMOST_URL'],
-        'ife_AUTHENTIK_DOMAIN' : app.config['ife_AUTHENTIK_DOMAIN'],
+        'ife_UPSTREAM_SSO_DOMAIN' : app.config['ife_UPSTREAM_SSO_DOMAIN'],
         'date_utc_now': datetime.utcnow()
     }
 

--- a/flaskr/router_localAuth.py
+++ b/flaskr/router_localAuth.py
@@ -10,6 +10,7 @@ from .appActions import appConfig
 
 IDP_DOMAIN = app.config['ife_IDP_DOMAIN']
 ife_MATTERMOST_URL = app.config['ife_MATTERMOST_URL']
+UPSTREAM_COOKIE = app.config['ife_UPSTREAM_COOKIE']
 
 local_auth = Blueprint('local_auth', __name__, template_folder='templates')
 
@@ -202,9 +203,9 @@ def logout():
     IFE_GLOBAL_SSO_CRED = request.cookies.get('IFE_GLOBAL_SSO_CRED', "")
 
     # If Authentik session exists, redirect to URL logout
-    authentik_session = request.cookies.get('authentik_session', False)
-    if authentik_session != False:
-        return redirect(app.config['ife_AUTHENTIK_DOMAIN'] + "/flows/-/default/invalidation/")
+    upstream_cookie_set = request.cookies.get(UPSTREAM_COOKIE, False)
+    if upstream_cookie_set != False:
+        return redirect(app.config['ife_UPSTREAM_SSO_DOMAIN'] + app.config['ife_UPSTREAM_SSO_PATH'])
     
     for key in list(session.keys()):
         session.pop(key)

--- a/flaskr/templates/logout.html
+++ b/flaskr/templates/logout.html
@@ -16,7 +16,7 @@
     
     <br><br>
     <p>Sign out of <a href="{{ ife_MATTERMOST_URL }}" class="user-select-all">Mattermost</a> to completely sign out of this device.</p>
-    <p>Sign back into <a href="{{ ife_AUTHENTIK_DOMAIN }}" class="user-select-all">Authentik</a> or <a href="/" class="user-select-all">IdP Broker</a>.</p>
+    <p>Sign back into <a href="{{ ife_UPSTREAM_SSO_DOMAIN }}" class="user-select-all">Authorization Portal</a> or <a href="/" class="user-select-all">IdP Broker</a>.</p>
 
 
     <p class="font-monospace text-muted user-select-all" style="font-size: 9px;">{{ CF_RAY_id }}</p>

--- a/idp.cfg
+++ b/idp.cfg
@@ -2,7 +2,9 @@
 idp_domain = idp.example.com
 sso_domain = example.com
 mattermost_url = https://mattermost.example.com
-authentik_domain = https://login.example.com
+upstream_sso_domain = https://login.example.com
+upstream_cookie = authentik_session
+upstream_sso_path = /flows/-/default/invalidation/
 trusted_root = example.com
 
 [DATABASE]


### PR DESCRIPTION
- Adding config for upstream authorization platform cookie
- Adding config for upstream authorization platform path
- Rename config for upstream authorization platform domain
- Updated language in README about upstream authorization platforms
